### PR TITLE
v1.3.12 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.3.12 April 05 2019 ####
+Support for Akka.Persistence 1.3.12.
+Added support for Akka.Persistence.Query.
+Upgraded to MongoDb v2.7.0 driver (2.8.0 doesn't support .NET 4.5)
+Added support for configurable, binary serialization via Akka.NET.
+
 
 #### 1.3.5 March 23 2018 ####
 Support for Akka.Persistence 1.3.5.

--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -13,7 +13,7 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitVersion)" />
     <PackageReference Include="Akka.Persistence.TCK" Version="1.3.11" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Mongo2Go" Version="2.2.1" />
+    <PackageReference Include="Mongo2Go" Version="2.2.8" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="Akka.Persistence.TCK" Version="1.3.11" />
+    <PackageReference Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Mongo2Go" Version="2.2.8" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />

--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="Akka.Persistence.TCK" Version="1.3.4-beta" />
+    <PackageReference Include="Akka.Persistence.TCK" Version="1.3.11" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Mongo2Go" Version="2.2.1" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />

--- a/src/Akka.Persistence.MongoDb.Tests/JournalTestActor.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/JournalTestActor.cs
@@ -1,0 +1,47 @@
+﻿using Akka.Actor;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    public class JournalTestActor : UntypedPersistentActor
+    {
+        public static Props Props(string persistenceId) => Actor.Props.Create(() => new JournalTestActor(persistenceId));
+
+        public sealed class DeleteCommand
+        {
+            public DeleteCommand(long toSequenceNr)
+            {
+                ToSequenceNr = toSequenceNr;
+            }
+
+            public long ToSequenceNr { get; }
+        }
+
+        public JournalTestActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+        }
+
+        public override string PersistenceId { get; }
+
+        protected override void OnRecover(object message)
+        {
+        }
+
+        protected override void OnCommand(object message)
+        {
+            switch (message) {
+                case DeleteCommand delete:
+                    DeleteMessages(delete.ToSequenceNr);
+                    Sender.Tell($"{delete.ToSequenceNr}-deleted");
+                    break;
+                case string cmd:
+                    var sender = Sender;
+                    Persist(cmd, e => sender.Tell($"{e}-done"));
+                    break;
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentEventsByPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentEventsByPersistenceIdsSpec.cs
@@ -1,0 +1,67 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MongoDbJournalSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Persistence.TCK.Journal;
+using Xunit;
+using Akka.Configuration;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Persistence.Query;
+using Xunit.Abstractions;
+using Akka.Util.Internal;
+using System;
+using Akka.Actor;
+using Akka.Streams.TestKit;
+using System.Linq;
+using System.Diagnostics;
+using Akka.Streams.Dsl;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    [Collection("MongoDbSpec")]
+    public class MongoDbCurrentEventsByPersistenceIdsSpec : Akka.Persistence.TCK.Query.CurrentEventsByPersistenceIdSpec, IClassFixture<DatabaseFixture>
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(0);
+        private readonly ITestOutputHelper _output;
+
+        public MongoDbCurrentEventsByPersistenceIdsSpec(ITestOutputHelper output, DatabaseFixture databaseFixture)
+            : base(CreateSpecConfig(databaseFixture, Counter.GetAndIncrement()), "MongoDbCurrentEventsByPersistenceIdsSpec", output)
+        {
+            _output = output;
+            output.WriteLine(databaseFixture.ConnectionString + Counter.Current);
+            ReadJournal = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 10s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + id + @"""
+                            auto-initialize = on
+                            collection = ""EventJournal""
+                        }
+                    }
+                    query {
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb""
+                            refresh-interval = 1s
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+
+    }
+
+
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentEventsByTagSpec.cs
@@ -1,0 +1,124 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MongoDbJournalSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Persistence.TCK.Journal;
+using Xunit;
+using Akka.Configuration;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Persistence.Query;
+using Xunit.Abstractions;
+using Akka.Util.Internal;
+using System;
+using Akka.Actor;
+using Akka.Streams.TestKit;
+using System.Linq;
+using System.Diagnostics;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    [Collection("MongoDbSpec")]
+    public class MongoDbCurrentEventsByTagSpec : Akka.Persistence.TCK.Query.CurrentEventsByTagSpec, IClassFixture<DatabaseFixture>
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(0);
+        private readonly ITestOutputHelper _output;
+
+        public MongoDbCurrentEventsByTagSpec(ITestOutputHelper output, DatabaseFixture databaseFixture)
+            : base(CreateSpecConfig(databaseFixture, Counter.GetAndIncrement()), "MongoDbCurrentEventsByTagSpec", output)
+        {
+            _output = output;
+            output.WriteLine(databaseFixture.ConnectionString + Counter.Current);
+            ReadJournal = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
+
+            var x = Sys.ActorOf(TestActor.Props("x"));
+            x.Tell("warm-up");
+            ExpectMsg("warm-up-done", TimeSpan.FromSeconds(10));
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 3s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + id + @"""
+                            auto-initialize = on
+                            collection = ""EventJournal""
+                            event-adapters {
+                                color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+                            }
+                            event-adapter-bindings = {
+                                ""System.String"" = color-tagger
+                            }
+                        }
+                    }
+                    query {
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb""
+                            refresh-interval = 1s
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+
+
+        //public override void ReadJournal_query_CurrentEventsByTag_should_find_existing_events()
+        //{
+        //    var a = Sys.ActorOf(TestActor.Props("a"));
+        //    a.Tell("warm-up");
+        //    ExpectMsg("warm-up-done", TimeSpan.FromSeconds(10));
+        //}
+
+
+        internal class TestActor : UntypedPersistentActor
+        {
+            public static Props Props(string persistenceId) => Actor.Props.Create(() => new TestActor(persistenceId));
+
+            public sealed class DeleteCommand
+            {
+                public DeleteCommand(long toSequenceNr)
+                {
+                    ToSequenceNr = toSequenceNr;
+                }
+
+                public long ToSequenceNr { get; }
+            }
+
+            public TestActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+            }
+
+            public override string PersistenceId { get; }
+
+            protected override void OnRecover(object message)
+            {
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message) {
+                    case DeleteCommand delete:
+                        DeleteMessages(delete.ToSequenceNr);
+                        Sender.Tell($"{delete.ToSequenceNr}-deleted");
+                        break;
+                    case string cmd:
+                        var sender = Sender;
+                        Persist(cmd, e => sender.Tell($"{e}-done"));
+                        break;
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentPersistenceIdsSpec.cs
@@ -1,0 +1,100 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MongoDbJournalSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Persistence.TCK.Journal;
+using Xunit;
+using Akka.Configuration;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Persistence.Query;
+using Xunit.Abstractions;
+using Akka.Util.Internal;
+using System;
+using Akka.Actor;
+using Akka.Streams.TestKit;
+using System.Linq;
+using System.Diagnostics;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    [Collection("MongoDbSpec")]
+    public class MongoDbCurrentPersistenceIdsSpec : Akka.Persistence.TCK.Query.CurrentPersistenceIdsSpec, IClassFixture<DatabaseFixture>
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(0);
+        private readonly ITestOutputHelper _output;
+
+        public MongoDbCurrentPersistenceIdsSpec(ITestOutputHelper output, DatabaseFixture databaseFixture)
+            : base(CreateSpecConfig(databaseFixture, Counter.GetAndIncrement()), "MongoDbCurrentPersistenceIdsSpec", output)
+        {
+            _output = output;
+            output.WriteLine(databaseFixture.ConnectionString + Counter.Current);
+            ReadJournal = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 3s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + id + @"""
+                            auto-initialize = on
+                            collection = ""EventJournal""
+                        }
+                    }
+                    query {
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb""
+                            refresh-interval = 1s
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+
+        public override void ReadJournal_query_CurrentPersistenceIds_should_not_see_new_events_after_complete()
+        {
+            var queries = ReadJournal.AsInstanceOf<ICurrentPersistenceIdsQuery>();
+
+            Setup("a", 1);
+            Setup("b", 1);
+            Setup("c", 1);
+
+            var greenSrc = queries.CurrentPersistenceIds();
+            var probe = greenSrc.RunWith(this.SinkProbe<string>(), Materializer);
+            var firstTwo = probe.Request(2).ExpectNextN(2);
+            Assert.Empty(firstTwo.Except(new[] { "a", "b", "c" }).ToArray());
+
+            var last = new[] { "a", "b", "c" }.Except(firstTwo).First();
+            Setup("d", 1);
+
+            probe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+            probe.Request(5)
+                .ExpectNext(last)
+                .ExpectComplete();
+        }
+
+        private IActorRef Setup(string persistenceId, int n)
+        {
+            var sw = Stopwatch.StartNew();
+            var pref = Sys.ActorOf(JournalTestActor.Props(persistenceId));
+            for (int i = 1; i <= n; i++) {
+                pref.Tell($"{persistenceId}-{i}");
+                ExpectMsg($"{persistenceId}-{i}-done", TimeSpan.FromSeconds(10), $"{persistenceId}-{i}-done");
+            }
+            _output.WriteLine(sw.ElapsedMilliseconds.ToString());
+            return pref;
+        }
+
+    }
+
+
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByPersistenceIdSpec.cs
@@ -1,0 +1,66 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MongoDbJournalSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Persistence.TCK.Journal;
+using Xunit;
+using Akka.Configuration;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Persistence.Query;
+using Xunit.Abstractions;
+using Akka.Util.Internal;
+using System;
+using Akka.Actor;
+using Akka.Streams.TestKit;
+using System.Linq;
+using System.Diagnostics;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    [Collection("MongoDbSpec")]
+    public class MongoDbEventsByPersistenceIdSpec : Akka.Persistence.TCK.Query.EventsByPersistenceIdSpec, IClassFixture<DatabaseFixture>
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(0);
+        private readonly ITestOutputHelper _output;
+
+        public MongoDbEventsByPersistenceIdSpec(ITestOutputHelper output, DatabaseFixture databaseFixture) 
+            : base(CreateSpecConfig(databaseFixture, Counter.GetAndIncrement()), "MongoDbEventsByPersistenceIdSpec", output)
+        {
+            _output = output;
+            output.WriteLine(databaseFixture.ConnectionString + Counter.Current);
+            ReadJournal = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 3s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + id + @"""
+                            auto-initialize = on
+                            collection = ""EventJournal""
+                        }
+                    }
+                    query {
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb""
+                            refresh-interval = 1s
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+
+    }
+
+    
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByTagSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByTagSpec.cs
@@ -1,0 +1,117 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MongoDbJournalSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Persistence.TCK.Journal;
+using Xunit;
+using Akka.Configuration;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Persistence.Query;
+using Xunit.Abstractions;
+using Akka.Util.Internal;
+using System;
+using Akka.Actor;
+using Akka.Streams.TestKit;
+using System.Linq;
+using System.Diagnostics;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    [Collection("MongoDbSpec")]
+    public class MongoDbEventsByTagSpec : Akka.Persistence.TCK.Query.EventsByTagSpec, IClassFixture<DatabaseFixture>
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(0);
+        private readonly ITestOutputHelper _output;
+
+        public MongoDbEventsByTagSpec(ITestOutputHelper output, DatabaseFixture databaseFixture)
+            : base(CreateSpecConfig(databaseFixture, Counter.GetAndIncrement()), "MongoDbCurrentEventsByTagSpec", output)
+        {
+            _output = output;
+            output.WriteLine(databaseFixture.ConnectionString + Counter.Current);
+            ReadJournal = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
+
+            var x = Sys.ActorOf(TestActor.Props("x"));
+            x.Tell("warm-up");
+            ExpectMsg("warm-up-done", TimeSpan.FromSeconds(10));
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 10s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + id + @"""
+                            auto-initialize = on
+                            collection = ""EventJournal""
+                            event-adapters {
+                                color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
+                            }
+                            event-adapter-bindings = {
+                                ""System.String"" = color-tagger
+                            }
+                        }
+                    }
+                    query {
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb""
+                            refresh-interval = 1s
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+
+
+
+        internal class TestActor : UntypedPersistentActor
+        {
+            public static Props Props(string persistenceId) => Actor.Props.Create(() => new TestActor(persistenceId));
+
+            public sealed class DeleteCommand
+            {
+                public DeleteCommand(long toSequenceNr)
+                {
+                    ToSequenceNr = toSequenceNr;
+                }
+
+                public long ToSequenceNr { get; }
+            }
+
+            public TestActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+            }
+
+            public override string PersistenceId { get; }
+
+            protected override void OnRecover(object message)
+            {
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message) {
+                    case DeleteCommand delete:
+                        DeleteMessages(delete.ToSequenceNr);
+                        Sender.Tell($"{delete.ToSequenceNr}-deleted");
+                        break;
+                    case string cmd:
+                        var sender = Sender;
+                        Persist(cmd, e => sender.Tell($"{e}-done"));
+                        break;
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
@@ -41,4 +41,36 @@ namespace Akka.Persistence.MongoDb.Tests
             return ConfigurationFactory.ParseString(specString);
         }
     }
+
+    [Collection("MongoDbSpec")]
+    public class MongoDbBinaryJournalSpec : JournalSpec, IClassFixture<DatabaseFixture>
+    {
+        protected override bool SupportsRejectingNonSerializableObjects { get; } = false;
+
+        public MongoDbBinaryJournalSpec(DatabaseFixture databaseFixture) : base(CreateSpecConfig(databaseFixture), "MongoDbJournalSpec")
+        {
+            Initialize();
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 3s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + @"""
+                            auto-initialize = on
+                            collection = ""EventJournal""
+                            stored-as = binary
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+    }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbPersistenceIdsSpec.cs
@@ -1,0 +1,87 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MongoDbJournalSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Persistence.TCK.Journal;
+using Xunit;
+using Akka.Configuration;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Persistence.Query;
+using Xunit.Abstractions;
+using Akka.Util.Internal;
+using System;
+using Akka.Actor;
+using Akka.Streams.TestKit;
+using System.Linq;
+using System.Diagnostics;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    [Collection("MongoDbSpec")]
+    public class MongoDbPersistenceIdsSpec : Akka.Persistence.TCK.Query.PersistenceIdsSpec, IClassFixture<DatabaseFixture>
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(0);
+        private readonly ITestOutputHelper _output;
+
+        public MongoDbPersistenceIdsSpec(ITestOutputHelper output, DatabaseFixture databaseFixture) 
+            : base(CreateSpecConfig(databaseFixture, Counter.GetAndIncrement()), "MongoDbPersistenceIdsSpec", output)
+        {
+            _output = output;
+            output.WriteLine(databaseFixture.ConnectionString + Counter.Current);
+            ReadJournal = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 3s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + id + @"""
+                            auto-initialize = on
+                            collection = ""EventJournal""
+                        }
+                    }
+                    query {
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb""
+                            refresh-interval = 1s
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+
+        [Fact]
+        public void ReadJournal_ConcurrentMessaging_should_work()
+        {
+            Enumerable.Range(1, 100).AsParallel().ForEach(_ => {
+                Setup(Guid.NewGuid().ToString(), 1);
+                Setup(Guid.NewGuid().ToString(), 1);
+            });
+        }
+
+        private IActorRef Setup(string persistenceId, int n)
+        {
+            var sw = Stopwatch.StartNew();
+            var pref = Sys.ActorOf(JournalTestActor.Props(persistenceId));
+            for (int i = 1; i <= n; i++) {
+                pref.Tell($"{persistenceId}-{i}");
+                ExpectMsg($"{persistenceId}-{i}-done", TimeSpan.FromSeconds(10), $"{persistenceId}-{i}-done");
+            }
+            _output.WriteLine(sw.ElapsedMilliseconds.ToString());
+            return pref;
+        }
+
+    }
+
+    
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
@@ -22,6 +22,7 @@ namespace Akka.Persistence.MongoDb.Tests
             mongoPersistence.JournalSettings.AutoInitialize.Should().BeFalse();
             mongoPersistence.JournalSettings.Collection.Should().Be("EventJournal");
             mongoPersistence.JournalSettings.MetadataCollection.Should().Be("Metadata");
+            mongoPersistence.JournalSettings.StoredAs.Should().BeOfType<StoredAsType>();
         }
 
         [Fact]
@@ -32,6 +33,7 @@ namespace Akka.Persistence.MongoDb.Tests
             mongoPersistence.SnapshotStoreSettings.ConnectionString.Should().Be(string.Empty);
             mongoPersistence.SnapshotStoreSettings.AutoInitialize.Should().BeFalse();
             mongoPersistence.SnapshotStoreSettings.Collection.Should().Be("SnapshotStore");
+            mongoPersistence.SnapshotStoreSettings.StoredAs.Should().BeOfType<StoredAsType>();
         }
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
@@ -39,4 +39,34 @@ namespace Akka.Persistence.MongoDb.Tests
             return ConfigurationFactory.ParseString(specString);
         }
     }
+
+    [Collection("MongoDbSpec")]
+    public class MongoDbBinarySnapshotStoreSpec : SnapshotStoreSpec, IClassFixture<DatabaseFixture>
+    {
+        public MongoDbBinarySnapshotStoreSpec(DatabaseFixture databaseFixture) : base(CreateSpecConfig(databaseFixture), "MongoDbSnapshotStoreSpec")
+        {
+            Initialize();
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 3s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    snapshot-store {
+                        plugin = ""akka.persistence.snapshot-store.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Snapshot.MongoDbSnapshotStore, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + @"""
+                            auto-initialize = on
+                            collection = ""SnapshotStore""
+                            stored-as = binary
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+    }
 }

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -9,7 +9,7 @@
     <EmbeddedResource Include="reference.conf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence" Version="1.3.5" />
+    <PackageReference Include="Akka.Persistence" Version="1.3.11" />
     <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -9,8 +9,10 @@
     <EmbeddedResource Include="reference.conf" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Akka.Persistence.Query" Version="1.3.11" />
+    <PackageReference Include="Akka.Streams" Version="1.3.11" />
+    <PackageReference Include="MongoDB.Driver" Version="2.7.0" />
     <PackageReference Include="Akka.Persistence" Version="1.3.11" />
-    <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -9,10 +9,8 @@
     <EmbeddedResource Include="reference.conf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence.Query" Version="1.3.11" />
-    <PackageReference Include="Akka.Streams" Version="1.3.11" />
+    <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
     <PackageReference Include="MongoDB.Driver" Version="2.7.0" />
-    <PackageReference Include="Akka.Persistence" Version="1.3.11" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/Akka.Persistence.MongoDb/Journal/JournalEntry.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/JournalEntry.cs
@@ -13,7 +13,7 @@ namespace Akka.Persistence.MongoDb.Journal
     /// Class used for storing intermediate result of the <see cref="IPersistentRepresentation"/>
     /// as BsonDocument into the MongoDB-Collection
     /// </summary>
-    public class JournalEntry 
+    public class JournalEntry
     {
         [BsonId]
         public string Id { get; set; }
@@ -32,5 +32,8 @@ namespace Akka.Persistence.MongoDb.Journal
 
         [BsonElement("Manifest")]
         public string Manifest { get; set; }
+
+        [BsonElement("SerializerId")]
+        public int? SerializerId { get; set; }
     }
 }

--- a/src/Akka.Persistence.MongoDb/Journal/JournalEntry.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/JournalEntry.cs
@@ -5,7 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using System.Collections.Generic;
 
 namespace Akka.Persistence.MongoDb.Journal
 {
@@ -33,6 +35,12 @@ namespace Akka.Persistence.MongoDb.Journal
         [BsonElement("Manifest")]
         public string Manifest { get; set; }
 
+        [BsonElement("Ordering")]
+        public BsonTimestamp Ordering { get; set; }
+
+        [BsonElement("Tags")]
+        public ICollection<string> Tags { get; set; } = new HashSet<string>();
+      
         [BsonElement("SerializerId")]
         public int? SerializerId { get; set; }
     }

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -6,12 +6,17 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Persistence.Journal;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using MongoDB.Bson;
 using Akka.Serialization;
 using Akka.Util;
 using MongoDB.Driver;
@@ -29,8 +34,16 @@ namespace Akka.Persistence.MongoDb.Journal
         private Lazy<IMongoCollection<JournalEntry>> _journalCollection;
         private Lazy<IMongoCollection<MetadataEntry>> _metadataCollection;
 
-        private readonly Func<IPersistentRepresentation, SerializationResult> _serialize;
+        private readonly HashSet<string> _allPersistenceIds = new HashSet<string>();
+        private readonly HashSet<IActorRef> _allPersistenceIdSubscribers = new HashSet<IActorRef>();
+        private readonly Dictionary<string, ISet<IActorRef>> _tagSubscribers = 
+            new Dictionary<string, ISet<IActorRef>>();
+        private readonly Dictionary<string, ISet<IActorRef>> _persistenceIdSubscribers 
+            = new Dictionary<string, ISet<IActorRef>>();
+
+        private readonly Func<object, SerializationResult> _serialize;
         private readonly Func<Type, object, string, int?, object> _deserialize;
+
 
         public MongoDbJournal()
         {
@@ -42,8 +55,8 @@ namespace Akka.Persistence.MongoDb.Journal
                 case StoredAsType.Binary:
                     _serialize = representation =>
                     {
-                        var serializer = serialization.FindSerializerFor(representation.Payload);
-                        return new SerializationResult(serializer.ToBinary(representation.Payload), serializer);
+                        var serializer = serialization.FindSerializerFor(representation);
+                        return new SerializationResult(serializer.ToBinary(representation), serializer);
                     };
                     _deserialize = (type, serialized, manifest, serializerId) =>
                     {
@@ -57,7 +70,7 @@ namespace Akka.Persistence.MongoDb.Journal
                     };
                     break;
                 default:
-                    _serialize = representation => new SerializationResult(representation.Payload, null);
+                    _serialize = representation => new SerializationResult(representation, null);
                     _deserialize = (type, serialized, manifest, serializerId) => serialized;
                     break;
             }
@@ -86,6 +99,10 @@ namespace Akka.Persistence.MongoDb.Journal
                             .Ascending(entry => entry.PersistenceId)
                             .Descending(entry => entry.SequenceNr))
                             .Wait();
+
+                    collection.Indexes.CreateOne(
+                        Builders<JournalEntry>.IndexKeys
+                        .Ascending(entry => entry.Ordering));
                 }
 
                 return collection;
@@ -109,6 +126,8 @@ namespace Akka.Persistence.MongoDb.Journal
 
         public override async Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, Action<IPersistentRepresentation> recoveryCallback)
         {
+            NotifyNewPersistenceIdAdded(persistenceId);
+
             // Limit allows only integer
             var limitValue = max >= int.MaxValue ? int.MaxValue : (int)max;
 
@@ -131,14 +150,55 @@ namespace Akka.Persistence.MongoDb.Journal
                 .Limit(limitValue)
                 .ToListAsync();
 
-            collections.ForEach(doc =>
-            {
+            collections.ForEach(doc => {
                 recoveryCallback(ToPersistenceRepresentation(doc, context.Sender));
             });
         }
 
+        /// <summary>
+        /// Replays all events with given tag withing provided boundaries from current database.
+        /// </summary>
+        /// <param name="replay">TBD</param>
+        /// <returns>TBD</returns>
+        private async Task<long> ReplayTaggedMessagesAsync(ReplayTaggedMessages replay)
+        {
+            // Limit allows only integer
+            var limitValue = replay.Max >= int.MaxValue ? int.MaxValue : (int)replay.Max;
+            var fromSequenceNr = replay.FromOffset;
+            var toSequenceNr = replay.ToOffset;
+            var tag = replay.Tag;
+
+            // Do not replay messages if limit equal zero
+            if (limitValue == 0) return 0;
+
+            var builder = Builders<JournalEntry>.Filter;
+            var filter = builder.AnyEq(x => x.Tags, tag);
+            if (fromSequenceNr > 0)
+                filter &= builder.Gt(x => x.Ordering, new BsonTimestamp(fromSequenceNr));
+            if (toSequenceNr != long.MaxValue)
+                filter &= builder.Lte(x => x.Ordering, new BsonTimestamp(toSequenceNr));
+
+            var sort = Builders<JournalEntry>.Sort.Ascending(x => x.Ordering);
+
+            long maxOrderingId = 0;
+            await _journalCollection.Value
+                .Find(filter)
+                .Sort(sort)
+                .Limit(limitValue)
+                .ForEachAsync(entry => {
+                    var persistent = new Persistent(entry.Payload, entry.SequenceNr, entry.PersistenceId, entry.Manifest, entry.IsDeleted, ActorRefs.NoSender, null);
+                    foreach (var adapted in AdaptFromJournal(persistent))
+                        replay.ReplyTo.Tell(new ReplayedTaggedMessage(adapted, tag, entry.Ordering.Value), ActorRefs.NoSender);
+                    maxOrderingId = entry.Ordering.Value;
+                });
+
+            return maxOrderingId;
+        }
+
         public override async Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
         {
+            NotifyNewPersistenceIdAdded(persistenceId);
+
             var builder = Builders<MetadataEntry>.Filter;
             var filter = builder.Eq(x => x.PersistenceId, persistenceId);
 
@@ -149,25 +209,38 @@ namespace Akka.Persistence.MongoDb.Journal
 
         protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
         {
+            var allTags = new HashSet<string>();
             var messageList = messages.ToList();
-            var writeTasks = messageList.Select(async message =>
-            {
+
+            var writeTasks = messageList.Select(async message => {
                 var persistentMessages = ((IImmutableList<IPersistentRepresentation>)message.Payload).ToArray();
 
                 var journalEntries = persistentMessages.Select(ToJournalEntry).ToList();
                 await _journalCollection.Value.InsertManyAsync(journalEntries);
+
+                NotifyNewPersistenceIdAdded(message.PersistenceId);
             });
 
             await SetHighSequenceId(messageList);
 
-            return await Task<IImmutableList<Exception>>
+            var result = await Task<IImmutableList<Exception>>
                 .Factory
                 .ContinueWhenAll(writeTasks.ToArray(),
                     tasks => tasks.Select(t => t.IsFaulted ? TryUnwrapException(t.Exception) : null).ToImmutableList());
+
+            if (HasTagSubscribers && allTags.Count != 0) {
+                foreach (var tag in allTags) {
+                    NotifyTagChange(tag);
+                }
+            }
+
+            return result;
         }
 
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
         {
+            NotifyNewPersistenceIdAdded(persistenceId);
+
             var builder = Builders<JournalEntry>.Filter;
             var filter = builder.Eq(x => x.PersistenceId, persistenceId);
 
@@ -179,13 +252,17 @@ namespace Akka.Persistence.MongoDb.Journal
 
         private JournalEntry ToJournalEntry(IPersistentRepresentation message)
         {
-            var serializationResult = _serialize(message);
+            object payload = message.Payload;
+            if (message.Payload is Tagged tagged)
+                payload = tagged.Payload;
+
+            var serializationResult = _serialize(payload);
             var serializer = serializationResult.Serializer;
             var hasSerializer = serializer != null;
 
             var manifest = "";
-            if (hasSerializer && serializer is SerializerWithStringManifest)
-                manifest = ((SerializerWithStringManifest)serializer).Manifest(message.Payload);
+            if (hasSerializer && serializer is SerializerWithStringManifest stringManifest)
+                manifest = stringManifest.Manifest(message.Payload);
             else if (hasSerializer && serializer.IncludeManifest)
                 manifest = message.GetType().TypeQualifiedName();
             else
@@ -196,11 +273,13 @@ namespace Akka.Persistence.MongoDb.Journal
             return new JournalEntry
             {
                 Id = message.PersistenceId + "_" + message.SequenceNr,
+                Ordering = new BsonTimestamp(0), // Auto-populates with timestamp
                 IsDeleted = message.IsDeleted,
                 Payload = serializationResult.Payload,
                 PersistenceId = message.PersistenceId,
                 SequenceNr = message.SequenceNr,
                 Manifest = manifest,
+                Tags = tagged.Tags?.ToList(),
                 SerializerId = serializer?.Identifier
             };
         }
@@ -235,5 +314,119 @@ namespace Akka.Persistence.MongoDb.Journal
 
             await _metadataCollection.Value.ReplaceOneAsync(filter, metadataEntry, new UpdateOptions() { IsUpsert = true });
         }
+
+        protected override bool ReceivePluginInternal(object message)
+        {
+            return message.Match()
+                .With<ReplayTaggedMessages>(replay => {
+                    ReplayTaggedMessagesAsync(replay)
+                    .PipeTo(replay.ReplyTo, success: h => new RecoverySuccess(h), failure: e => new ReplayMessagesFailure(e));
+                })
+                .With<SubscribePersistenceId>(subscribe => {
+                    AddPersistenceIdSubscriber(Sender, subscribe.PersistenceId);
+                    Context.Watch(Sender);
+                })
+                .With<SubscribeAllPersistenceIds>(subscribe => {
+                    AddAllPersistenceIdSubscriber(Sender);
+                    Context.Watch(Sender);
+                })
+                .With<SubscribeTag>(subscribe => {
+                    AddTagSubscriber(Sender, subscribe.Tag);
+                    Context.Watch(Sender);
+                })
+                .With<Terminated>(terminated => RemoveSubscriber(terminated.ActorRef))
+                .WasHandled;
+        }
+
+        private void AddAllPersistenceIdSubscriber(IActorRef subscriber)
+        {
+            lock (_allPersistenceIdSubscribers) {
+                _allPersistenceIdSubscribers.Add(subscriber);
+            }
+            subscriber.Tell(new CurrentPersistenceIds(GetAllPersistenceIds()));
+        }
+
+        private void AddTagSubscriber(IActorRef subscriber, string tag)
+        {
+            if (!_tagSubscribers.TryGetValue(tag, out var subscriptions)) {
+                subscriptions = new HashSet<IActorRef>();
+                _tagSubscribers.Add(tag, subscriptions);
+            }
+
+            subscriptions.Add(subscriber);
+        }
+
+        private IEnumerable<string> GetAllPersistenceIds()
+        {
+            return _journalCollection.Value.AsQueryable()
+                .Select(je => je.PersistenceId)
+                .Distinct()
+                .ToList();
+        }
+
+        private void AddPersistenceIdSubscriber(IActorRef subscriber, string persistenceId)
+        {
+            if (!_persistenceIdSubscribers.TryGetValue(persistenceId, out var subscriptions)) {
+                subscriptions = new HashSet<IActorRef>();
+                _persistenceIdSubscribers.Add(persistenceId, subscriptions);
+            }
+
+            subscriptions.Add(subscriber);
+        }
+
+        private void RemoveSubscriber(IActorRef subscriber)
+        {
+            var pidSubscriptions = _persistenceIdSubscribers.Values.Where(x => x.Contains(subscriber));
+            foreach (var subscription in pidSubscriptions)
+                subscription.Remove(subscriber);
+
+            var tagSubscriptions = _tagSubscribers.Values.Where(x => x.Contains(subscriber));
+            foreach (var subscription in tagSubscriptions)
+                subscription.Remove(subscriber);
+
+            _allPersistenceIdSubscribers.Remove(subscriber);
+        }
+
+        protected bool HasAllPersistenceIdSubscribers => _allPersistenceIdSubscribers.Count != 0;
+        protected bool HasTagSubscribers => _tagSubscribers.Count != 0;
+        protected bool HasPersistenceIdSubscribers => _persistenceIdSubscribers.Count != 0;
+
+        private void NotifyNewPersistenceIdAdded(string persistenceId)
+        {
+            var isNew = TryAddPersistenceId(persistenceId);
+            if (isNew && HasAllPersistenceIdSubscribers) {
+                var added = new PersistenceIdAdded(persistenceId);
+                foreach (var subscriber in _allPersistenceIdSubscribers)
+                    subscriber.Tell(added);
+            }
+        }
+
+        private bool TryAddPersistenceId(string persistenceId)
+        {
+            lock (_allPersistenceIds) {
+                return _allPersistenceIds.Add(persistenceId);
+            }
+        }
+
+        private void NotifyPersistenceIdChange(string persistenceId)
+        {
+            if (_persistenceIdSubscribers.TryGetValue(persistenceId, out var subscribers)) {
+                var changed = new EventAppended(persistenceId);
+                foreach (var subscriber in subscribers)
+                    subscriber.Tell(changed);
+            }
+        }
+
+        private void NotifyTagChange(string tag)
+        {
+            if (_tagSubscribers.TryGetValue(tag, out var subscribers)) {
+                var changed = new TaggedEventAppended(tag);
+                foreach (var subscriber in subscribers)
+                    subscriber.Tell(changed);
+            }
+        }
+
     }
+
+
 }

--- a/src/Akka.Persistence.MongoDb/MongoDbSettings.cs
+++ b/src/Akka.Persistence.MongoDb/MongoDbSettings.cs
@@ -10,6 +10,12 @@ using Akka.Configuration;
 
 namespace Akka.Persistence.MongoDb
 {
+    public enum StoredAsType
+    {
+        Object,
+        Binary
+    }
+
     /// <summary>
     /// Settings for the MongoDB persistence implementation, parsed from HOCON configuration.
     /// </summary>
@@ -30,14 +36,23 @@ namespace Akka.Persistence.MongoDb
         /// </summary>
         public string Collection { get; private set; }
 
+        /// <summary>
+        /// Specifies data type for payload column.
+        /// </summary>
+        public StoredAsType StoredAs { get; private set; }
+
         protected MongoDbSettings(Config config)
         {
             ConnectionString = config.GetString("connection-string");
             Collection = config.GetString("collection");
             AutoInitialize = config.GetBoolean("auto-initialize");
+
+            StoredAs = StoredAsType.Object;
+
+            if (Enum.TryParse(config.GetString("stored-as"), true, out StoredAsType storedAs))
+                StoredAs = storedAs;
         }
     }
-
 
     /// <summary>
     /// Settings for the MongoDB journal implementation, parsed from HOCON configuration.
@@ -55,7 +70,6 @@ namespace Akka.Persistence.MongoDb
             MetadataCollection = config.GetString("metadata-collection");
         }
     }
-
 
     /// <summary>
     /// Settings for the MongoDB snapshot implementation, parsed from HOCON configuration.

--- a/src/Akka.Persistence.MongoDb/Query/AllPersistenceIdsPublisher.cs
+++ b/src/Akka.Persistence.MongoDb/Query/AllPersistenceIdsPublisher.cs
@@ -1,0 +1,62 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AllPersistenceIdsPublisher.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Streams.Actors;
+
+namespace Akka.Persistence.MongoDb.Query
+{
+    internal sealed class AllPersistenceIdsPublisher : ActorPublisher<string>
+    {
+        public static Props Props(bool liveQuery, string writeJournalPluginId)
+        {
+            return Actor.Props.Create(() => new AllPersistenceIdsPublisher(liveQuery, writeJournalPluginId));
+        }
+
+        private readonly bool _liveQuery;
+        private readonly IActorRef _journalRef;
+
+        private readonly DeliveryBuffer<string> _buffer;
+
+        public AllPersistenceIdsPublisher(bool liveQuery, string writeJournalPluginId)
+        {
+            _liveQuery = liveQuery;
+            _buffer = new DeliveryBuffer<string>(OnNext);
+            _journalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
+        }
+
+        protected override bool Receive(object message) => message.Match()
+            .With<Request>(_ => {
+                _journalRef.Tell(SubscribeAllPersistenceIds.Instance);
+                Become(Active);
+            })
+            .With<Cancel>(_ => Context.Stop(Self))
+            .WasHandled;
+
+        private bool Active(object message) => message.Match()
+            .With<CurrentPersistenceIds>(current => {
+                _buffer.AddRange(current.AllPersistenceIds);
+                _buffer.DeliverBuffer(TotalDemand);
+
+                if (!_liveQuery && _buffer.IsEmpty)
+                    OnCompleteThenStop();
+            })
+            .With<PersistenceIdAdded>(added => {
+                if (_liveQuery) {
+                    _buffer.Add(added.PersistenceId);
+                    _buffer.DeliverBuffer(TotalDemand);
+                }
+            })
+            .With<Request>(_ => {
+                _buffer.DeliverBuffer(TotalDemand);
+                if (!_liveQuery && _buffer.IsEmpty)
+                    OnCompleteThenStop();
+            })
+            .With<Cancel>(_ => Context.Stop(Self))
+            .WasHandled;
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Query/DeliveryBuffer.cs
+++ b/src/Akka.Persistence.MongoDb/Query/DeliveryBuffer.cs
@@ -1,0 +1,61 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AllPersistenceIdsPublisher.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Akka.Persistence.MongoDb.Query
+{
+    internal class DeliveryBuffer<T>
+    {
+        public ImmutableArray<T> Buffer { get; private set; } = ImmutableArray<T>.Empty;
+        public bool IsEmpty => Buffer.IsEmpty;
+        public int Length => Buffer.Length;
+
+        private readonly Action<T> _onNext;
+
+        public DeliveryBuffer(Action<T> onNext)
+        {
+            _onNext = onNext;
+        }
+
+        public void Add(T element)
+        {
+            Buffer = Buffer.Add(element);
+        }
+        public void AddRange(IEnumerable<T> elements)
+        {
+            Buffer = Buffer.AddRange(elements);
+        }
+
+        public void DeliverBuffer(long demand)
+        {
+            if (!Buffer.IsEmpty && demand > 0) {
+                var totalDemand = Math.Min((int)demand, Buffer.Length);
+                if (Buffer.Length == 1) {
+                    // optimize for this common case
+                    _onNext(Buffer[0]);
+                    Buffer = ImmutableArray<T>.Empty;
+                }
+                else if (demand <= int.MaxValue) {
+                    for (var i = 0; i < totalDemand; i++)
+                        _onNext(Buffer[i]);
+
+                    Buffer = Buffer.RemoveRange(0, totalDemand);
+                }
+                else {
+                    foreach (var element in Buffer)
+                        _onNext(element);
+
+                    Buffer = ImmutableArray<T>.Empty;
+                }
+            }
+        }
+
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Query/EventByPersistenceIdPublisher.cs
+++ b/src/Akka.Persistence.MongoDb/Query/EventByPersistenceIdPublisher.cs
@@ -1,0 +1,208 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventsByPersistenceIdPublisher.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Persistence.Query;
+using Akka.Streams.Actors;
+
+namespace Akka.Persistence.MongoDb.Query
+{
+    internal static class EventsByPersistenceIdPublisher
+    {
+        [Serializable]
+        public sealed class Continue
+        {
+            public static readonly Continue Instance = new Continue();
+
+            private Continue()
+            {
+            }
+        }
+
+        public static Props Props(string persistenceId, long fromSequenceNr, long toSequenceNr, TimeSpan? refreshDuration, int maxBufferSize, string writeJournalPluginId)
+        {
+            return refreshDuration.HasValue
+                ? Actor.Props.Create(() => new LiveEventsByPersistenceIdPublisher(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, writeJournalPluginId, refreshDuration.Value))
+                : Actor.Props.Create(() => new CurrentEventsByPersistenceIdPublisher(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, writeJournalPluginId));
+        }
+    }
+
+    internal abstract class AbstractEventsByPersistenceIdPublisher : ActorPublisher<EventEnvelope>
+    {
+        private ILoggingAdapter _log;
+
+        protected DeliveryBuffer<EventEnvelope> Buffer;
+        protected readonly IActorRef JournalRef;
+        protected long CurrentSequenceNr;
+
+        protected AbstractEventsByPersistenceIdPublisher(string persistenceId, long fromSequenceNr, long toSequenceNr, int maxBufferSize, string writeJournalPluginId)
+        {
+            PersistenceId = persistenceId;
+            CurrentSequenceNr = FromSequenceNr = fromSequenceNr;
+            ToSequenceNr = toSequenceNr;
+            MaxBufferSize = maxBufferSize;
+            WriteJournalPluginId = writeJournalPluginId;
+            Buffer = new DeliveryBuffer<EventEnvelope>(OnNext);
+
+            JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
+        }
+
+        protected ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
+        protected string PersistenceId { get; }
+        protected long FromSequenceNr { get; }
+        protected long ToSequenceNr { get; set; }
+        protected int MaxBufferSize { get; }
+        protected string WriteJournalPluginId { get; }
+
+        protected bool IsTimeForReplay => (Buffer.IsEmpty || Buffer.Length <= MaxBufferSize / 2) && (CurrentSequenceNr <= ToSequenceNr);
+
+        protected abstract void ReceiveInitialRequest();
+        protected abstract void ReceiveIdleRequest();
+        protected abstract void ReceiveRecoverySuccess(long highestSequenceNr);
+
+        protected override bool Receive(object message)
+        {
+            return Init(message);
+        }
+
+        protected bool Init(object message)
+        {
+            return message.Match()
+                .With<EventsByPersistenceIdPublisher.Continue>(() => { })
+                .With<Request>(_ => ReceiveInitialRequest())
+                .With<Cancel>(_ => Context.Stop(Self))
+                .WasHandled;
+        }
+
+        protected bool Idle(object message)
+        {
+            return message.Match()
+                .With<EventsByPersistenceIdPublisher.Continue>(() => {
+                    if (IsTimeForReplay) Replay();
+                })
+                .With<EventAppended>(() => {
+                    if (IsTimeForReplay) Replay();
+                })
+                .With<Request>(_ => ReceiveIdleRequest())
+                .With<Cancel>(_ => Context.Stop(Self))
+                .WasHandled;
+        }
+
+        protected void Replay()
+        {
+            var limit = MaxBufferSize - Buffer.Length;
+            Log.Debug("request replay for persistenceId [{0}] from [{1}] to [{2}] limit [{3}]", PersistenceId, CurrentSequenceNr, ToSequenceNr, limit);
+            JournalRef.Tell(new ReplayMessages(CurrentSequenceNr, ToSequenceNr, limit, PersistenceId, Self));
+            Context.Become(Replaying(limit));
+        }
+
+        protected Receive Replaying(int limit)
+        {
+            return message => message.Match()
+                .With<ReplayedMessage>(replayed => {
+                    var seqNr = replayed.Persistent.SequenceNr;
+                    Buffer.Add(new EventEnvelope(
+                        offset: new Sequence(seqNr),
+                        persistenceId: PersistenceId,
+                        sequenceNr: seqNr,
+                        @event: replayed.Persistent.Payload));
+                    CurrentSequenceNr = seqNr + 1;
+                    Buffer.DeliverBuffer(TotalDemand);
+                })
+                .With<RecoverySuccess>(success => {
+                    Log.Debug("replay completed for persistenceId [{0}], currSeqNo [{1}]", PersistenceId, CurrentSequenceNr);
+                    ReceiveRecoverySuccess(success.HighestSequenceNr);
+                })
+                .With<ReplayMessagesFailure>(failure => {
+                    Log.Debug("replay failed for persistenceId [{0}], due to [{1}]", PersistenceId, failure.Cause.Message);
+                    Buffer.DeliverBuffer(TotalDemand);
+                    OnErrorThenStop(failure.Cause);
+                })
+                .With<Request>(_ => Buffer.DeliverBuffer(TotalDemand))
+                .With<EventsByPersistenceIdPublisher.Continue>(() => { }) // skip during replay
+                .With<EventAppended>(() => { }) // skip during replay
+                .With<Cancel>(_ => Context.Stop(Self))
+                .WasHandled;
+        }
+    }
+
+    internal sealed class LiveEventsByPersistenceIdPublisher : AbstractEventsByPersistenceIdPublisher
+    {
+        private readonly ICancelable _tickCancelable;
+
+        public LiveEventsByPersistenceIdPublisher(string persistenceId, long fromSequenceNr, long toSequenceNr, int maxBufferSize, string writeJournalPluginId, TimeSpan refreshInterval)
+            : base(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, writeJournalPluginId)
+        {
+            _tickCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(refreshInterval, refreshInterval, Self, EventsByPersistenceIdPublisher.Continue.Instance, Self);
+        }
+
+        protected override void PostStop()
+        {
+            _tickCancelable.Cancel();
+            base.PostStop();
+        }
+
+        protected override void ReceiveInitialRequest()
+        {
+            JournalRef.Tell(new SubscribePersistenceId(PersistenceId));
+            Replay();
+        }
+
+        protected override void ReceiveIdleRequest()
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (Buffer.IsEmpty && CurrentSequenceNr > ToSequenceNr)
+                OnCompleteThenStop();
+        }
+
+        protected override void ReceiveRecoverySuccess(long highestSequenceNr)
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (Buffer.IsEmpty && CurrentSequenceNr > ToSequenceNr)
+                OnCompleteThenStop();
+
+            Context.Become(Idle);
+        }
+    }
+
+    internal sealed class CurrentEventsByPersistenceIdPublisher : AbstractEventsByPersistenceIdPublisher
+    {
+        public CurrentEventsByPersistenceIdPublisher(string persistenceId, long fromSequenceNr, long toSequenceNr, int maxBufferSize, string writeJournalPluginId)
+            : base(persistenceId, fromSequenceNr, toSequenceNr, maxBufferSize, writeJournalPluginId)
+        {
+        }
+
+        protected override void ReceiveInitialRequest()
+        {
+            Replay();
+        }
+
+        protected override void ReceiveIdleRequest()
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (Buffer.IsEmpty && CurrentSequenceNr > ToSequenceNr)
+                OnCompleteThenStop();
+            else
+                Self.Tell(EventsByPersistenceIdPublisher.Continue.Instance);
+        }
+
+        protected override void ReceiveRecoverySuccess(long highestSequenceNr)
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (highestSequenceNr < ToSequenceNr)
+                ToSequenceNr = highestSequenceNr;
+            if (Buffer.IsEmpty && (CurrentSequenceNr > ToSequenceNr || CurrentSequenceNr == FromSequenceNr))
+                OnCompleteThenStop();
+            else
+                Self.Tell(EventsByPersistenceIdPublisher.Continue.Instance);
+
+            Context.Become(Idle);
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
+++ b/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
@@ -1,0 +1,200 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventsByTagPublisher.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Persistence.Query;
+using Akka.Streams.Actors;
+
+namespace Akka.Persistence.MongoDb.Query
+{
+    internal static class EventsByTagPublisher
+    {
+        [Serializable]
+        public sealed class Continue
+        {
+            public static readonly Continue Instance = new Continue();
+
+            private Continue()
+            {
+            }
+        }
+
+        public static Props Props(string tag, long fromOffset, long toOffset, TimeSpan? refreshInterval, int maxBufferSize, string writeJournalPluginId)
+        {
+            return refreshInterval.HasValue
+                ? Actor.Props.Create(() => new LiveEventsByTagPublisher(tag, fromOffset, toOffset, refreshInterval.Value, maxBufferSize, writeJournalPluginId))
+                : Actor.Props.Create(() => new CurrentEventsByTagPublisher(tag, fromOffset, toOffset, maxBufferSize, writeJournalPluginId));
+        }
+    }
+
+    internal abstract class AbstractEventsByTagPublisher : ActorPublisher<EventEnvelope>
+    {
+        private ILoggingAdapter _log;
+
+        protected readonly DeliveryBuffer<EventEnvelope> Buffer;
+        protected readonly IActorRef JournalRef;
+        protected long CurrentOffset;
+        protected AbstractEventsByTagPublisher(string tag, long fromOffset, int maxBufferSize, string writeJournalPluginId)
+        {
+            Tag = tag;
+            CurrentOffset = FromOffset = fromOffset;
+            MaxBufferSize = maxBufferSize;
+            WriteJournalPluginId = writeJournalPluginId;
+            Buffer = new DeliveryBuffer<EventEnvelope>(OnNext);
+            JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
+        }
+
+        protected ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
+        protected string Tag { get; }
+        protected long FromOffset { get; }
+        protected abstract long ToOffset { get; }
+        protected int MaxBufferSize { get; }
+        protected string WriteJournalPluginId { get; }
+
+        protected bool IsTimeForReplay => (Buffer.IsEmpty || Buffer.Length <= MaxBufferSize / 2) && (CurrentOffset <= ToOffset);
+
+        protected abstract void ReceiveInitialRequest();
+        protected abstract void ReceiveIdleRequest();
+        protected abstract void ReceiveRecoverySuccess(long highestSequenceNr);
+
+        protected override bool Receive(object message) => message.Match()
+            .With<Request>(_ => ReceiveInitialRequest())
+            .With<EventsByTagPublisher.Continue>(() => { })
+            .With<Cancel>(_ => Context.Stop(Self))
+            .WasHandled;
+
+        protected bool Idle(object message) => message.Match()
+            .With<EventsByTagPublisher.Continue>(() => {
+                if (IsTimeForReplay) Replay();
+            })
+            .With<TaggedEventAppended>(() => {
+                if (IsTimeForReplay) Replay();
+            })
+            .With<Request>(ReceiveIdleRequest)
+            .With<Cancel>(() => Context.Stop(Self))
+            .WasHandled;
+
+        protected void Replay()
+        {
+            var limit = MaxBufferSize - Buffer.Length;
+            Log.Debug("request replay for tag [{0}] from [{1}] to [{2}] limit [{3}]", Tag, CurrentOffset, ToOffset, limit);
+            JournalRef.Tell(new ReplayTaggedMessages(CurrentOffset, ToOffset, limit, Tag, Self));
+            Context.Become(Replaying(limit));
+        }
+
+        protected Receive Replaying(int limit)
+        {
+            return message => message.Match()
+                .With<ReplayedTaggedMessage>(replayed => {
+                    Buffer.Add(new EventEnvelope(
+                        offset: new Sequence(replayed.Offset),
+                        persistenceId: replayed.Persistent.PersistenceId,
+                        sequenceNr: replayed.Persistent.SequenceNr,
+                        @event: replayed.Persistent.Payload));
+
+                    CurrentOffset = replayed.Offset;
+                    Buffer.DeliverBuffer(TotalDemand);
+                })
+                .With<RecoverySuccess>(success => {
+                    Log.Debug("replay completed for tag [{0}], currOffset [{1}]", Tag, CurrentOffset);
+                    ReceiveRecoverySuccess(success.HighestSequenceNr);
+                })
+                .With<ReplayMessagesFailure>(failure => {
+                    Log.Debug("replay failed for tag [{0}], due to [{1}]", Tag, failure.Cause.Message);
+                    Buffer.DeliverBuffer(TotalDemand);
+                    OnErrorThenStop(failure.Cause);
+                })
+                .With<Request>(_ => Buffer.DeliverBuffer(TotalDemand))
+                .With<EventsByTagPublisher.Continue>(() => { })
+                .With<TaggedEventAppended>(() => { })
+                .With<Cancel>(() => Context.Stop(Self))
+                .WasHandled;
+        }
+    }
+
+    internal sealed class LiveEventsByTagPublisher : AbstractEventsByTagPublisher
+    {
+        private readonly ICancelable _tickCancelable;
+        public LiveEventsByTagPublisher(string tag, long fromOffset, long toOffset, TimeSpan refreshInterval, int maxBufferSize, string writeJournalPluginId)
+            : base(tag, fromOffset, maxBufferSize, writeJournalPluginId)
+        {
+            ToOffset = toOffset;
+            _tickCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(refreshInterval, refreshInterval, Self, EventsByTagPublisher.Continue.Instance, Self);
+        }
+
+        protected override long ToOffset { get; }
+
+        protected override void PostStop()
+        {
+            _tickCancelable.Cancel();
+            base.PostStop();
+        }
+
+        protected override void ReceiveInitialRequest()
+        {
+            JournalRef.Tell(new SubscribeTag(Tag));
+            Replay();
+        }
+
+        protected override void ReceiveIdleRequest()
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+                OnCompleteThenStop();
+        }
+
+        protected override void ReceiveRecoverySuccess(long highestSequenceNr)
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+                OnCompleteThenStop();
+
+            Context.Become(Idle);
+        }
+    }
+
+    internal sealed class CurrentEventsByTagPublisher : AbstractEventsByTagPublisher
+    {
+        public CurrentEventsByTagPublisher(string tag, long fromOffset, long toOffset, int maxBufferSize, string writeJournalPluginId)
+            : base(tag, fromOffset, maxBufferSize, writeJournalPluginId)
+        {
+            _toOffset = toOffset;
+        }
+
+        private long _toOffset;
+        protected override long ToOffset => _toOffset;
+        protected override void ReceiveInitialRequest()
+        {
+            Replay();
+        }
+
+        protected override void ReceiveIdleRequest()
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+                OnCompleteThenStop();
+            else
+                Self.Tell(EventsByTagPublisher.Continue.Instance);
+        }
+
+        protected override void ReceiveRecoverySuccess(long highestSequenceNr)
+        {
+            Buffer.DeliverBuffer(TotalDemand);
+            if (highestSequenceNr < ToOffset)
+                _toOffset = highestSequenceNr;
+
+            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+                OnCompleteThenStop();
+            else
+                Self.Tell(EventsByTagPublisher.Continue.Instance);
+
+            Context.Become(Idle);
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Query/Messages.cs
+++ b/src/Akka.Persistence.MongoDb/Query/Messages.cs
@@ -1,0 +1,257 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="QueryApi.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Event;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akka.Persistence.MongoDb.Query
+{
+    /// <summary>
+    /// TBD
+    /// </summary>
+    public interface ISubscriptionCommand { }
+
+    /// <summary>
+    /// Subscribe the `sender` to changes (appended events) for a specific `persistenceId`.
+    /// Used by query-side. The journal will send <see cref="EventAppended"/> messages to
+    /// the subscriber when <see cref="AsyncWriteJournal.WriteMessagesAsync"/> has been called.
+    /// </summary>
+    public sealed class SubscribePersistenceId : ISubscriptionCommand
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly string PersistenceId;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="persistenceId">TBD</param>
+        public SubscribePersistenceId(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+        }
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    public sealed class EventAppended : IDeadLetterSuppression
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly string PersistenceId;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="persistenceId">TBD</param>
+        public EventAppended(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+        }
+    }
+
+    /// <summary>
+    /// Subscribe the `sender` to current and new persistenceIds.
+    /// Used by query-side. The journal will send one <see cref="CurrentPersistenceIds"/> to the
+    /// subscriber followed by <see cref="PersistenceIdAdded"/> messages when new persistenceIds
+    /// are created.
+    /// </summary>
+    public sealed class SubscribeAllPersistenceIds : ISubscriptionCommand
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public static readonly SubscribeAllPersistenceIds Instance = new SubscribeAllPersistenceIds();
+        private SubscribeAllPersistenceIds() { }
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    public sealed class CurrentPersistenceIds : IDeadLetterSuppression
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly IEnumerable<string> AllPersistenceIds;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="allPersistenceIds">TBD</param>
+        public CurrentPersistenceIds(IEnumerable<string> allPersistenceIds)
+        {
+            AllPersistenceIds = allPersistenceIds.ToImmutableHashSet();
+        }
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    
+    public sealed class PersistenceIdAdded : IDeadLetterSuppression
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly string PersistenceId;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="persistenceId">TBD</param>
+        public PersistenceIdAdded(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+        }
+    }
+
+    /// <summary>
+    /// Subscribe the `sender` to changes (appended events) for a specific `tag`.
+    /// Used by query-side. The journal will send <see cref="TaggedEventAppended"/> messages to
+    /// the subscriber when `asyncWriteMessages` has been called.
+    /// Events are tagged by wrapping in <see cref="Tagged"/>
+    /// via an <see cref="IEventAdapter"/>.
+    /// </summary>
+    public sealed class SubscribeTag : ISubscriptionCommand
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly string Tag;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="tag">TBD</param>
+        public SubscribeTag(string tag)
+        {
+            Tag = tag;
+        }
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    public sealed class TaggedEventAppended : IDeadLetterSuppression
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly string Tag;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="tag">TBD</param>
+        public TaggedEventAppended(string tag)
+        {
+            Tag = tag;
+        }
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    public sealed class ReplayTaggedMessages : IJournalRequest
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly long FromOffset;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly long ToOffset;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly long Max;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly string Tag;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly IActorRef ReplyTo;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplayTaggedMessages"/> class.
+        /// </summary>
+        /// <param name="fromOffset">TBD</param>
+        /// <param name="toOffset">TBD</param>
+        /// <param name="max">TBD</param>
+        /// <param name="tag">TBD</param>
+        /// <param name="replyTo">TBD</param>
+        /// <exception cref="ArgumentException">
+        /// This exception is thrown for a number of reasons. These include the following:
+        /// <ul>
+        /// <li>The specified <paramref name="fromOffset"/> is less than zero.</li>
+        /// <li>The specified <paramref name="toOffset"/> is less than or equal to zero.</li>
+        /// <li>The specified <paramref name="max"/> is less than or equal to zero.</li>
+        /// </ul>
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// This exception is thrown when the specified <paramref name="tag"/> is null or empty.
+        /// </exception>
+        public ReplayTaggedMessages(long fromOffset, long toOffset, long max, string tag, IActorRef replyTo)
+        {
+            if (fromOffset < 0) throw new ArgumentException("From offset may not be a negative number", nameof(fromOffset));
+            if (toOffset <= 0) throw new ArgumentException("To offset must be a positive number", nameof(toOffset));
+            if (max <= 0) throw new ArgumentException("Maximum number of replayed messages must be a positive number", nameof(max));
+            if (string.IsNullOrEmpty(tag)) throw new ArgumentNullException(nameof(tag), "Replay tagged messages require a tag value to be provided");
+
+            FromOffset = fromOffset;
+            ToOffset = toOffset;
+            Max = max;
+            Tag = tag;
+            ReplyTo = replyTo;
+        }
+    }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    public sealed class ReplayedTaggedMessage : INoSerializationVerificationNeeded, IDeadLetterSuppression
+    {
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly IPersistentRepresentation Persistent;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly string Tag;
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public readonly long Offset;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="persistent">TBD</param>
+        /// <param name="tag">TBD</param>
+        /// <param name="offset">TBD</param>
+        public ReplayedTaggedMessage(IPersistentRepresentation persistent, string tag, long offset)
+        {
+            Persistent = persistent;
+            Tag = tag;
+            Offset = offset;
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournal.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.Persistence.Query;
+using Akka.Streams.Dsl;
+using MongoDB.Driver;
+
+namespace Akka.Persistence.MongoDb.Query
+{
+    public class MongoDbReadJournal : IReadJournal,
+        IPersistenceIdsQuery,
+        ICurrentPersistenceIdsQuery,
+        IEventsByPersistenceIdQuery,
+        ICurrentEventsByPersistenceIdQuery,
+        IEventsByTagQuery,
+        ICurrentEventsByTagQuery
+    {
+        /// <summary>
+        /// HOCON identifier
+        /// </summary>
+        public const string Identifier = "akka.persistence.query.mongodb";
+
+        private readonly TimeSpan _refreshInterval;
+        private readonly string _writeJournalPluginId;
+        private readonly int _maxBufferSize;
+        
+        /// <inheritdoc />
+        public MongoDbReadJournal(ExtendedActorSystem system, Config config)
+        {
+            _refreshInterval = config.GetTimeSpan("refresh-interval");
+            _writeJournalPluginId = config.GetString("write-plugin");
+            _maxBufferSize = config.GetInt("max-buffer-size");
+        }
+
+        /// <summary>
+        /// Returns a default query configuration for akka persistence SQLite-based journals and snapshot stores.
+        /// </summary>
+        /// <returns></returns>
+        public static Config DefaultConfiguration()
+        {
+            return ConfigurationFactory.FromResource<MongoDbReadJournal>(
+                "Akka.Persistence.MongoDb.reference.conf");
+        }
+
+        /// <summary>
+        /// <para>
+        /// <see cref="PersistenceIds"/> is used for retrieving all `persistenceIds` of all
+        /// persistent actors.
+        /// </para>
+        /// The returned event stream is unordered and you can expect different order for multiple
+        /// executions of the query.
+        /// <para>
+        /// The stream is not completed when it reaches the end of the currently used `persistenceIds`,
+        /// but it continues to push new `persistenceIds` when new persistent actors are created.
+        /// Corresponding query that is completed when it reaches the end of the currently
+        /// currently used `persistenceIds` is provided by <see cref="CurrentPersistenceIds"/>.
+        /// </para>
+        /// The SQL write journal is notifying the query side as soon as new `persistenceIds` are
+        /// created and there is no periodic polling or batching involved in this query.
+        /// <para>
+        /// The stream is completed with failure if there is a failure in executing the query in the
+        /// backend journal.
+        /// </para>
+        /// </summary>
+        public Source<string, NotUsed> PersistenceIds() =>
+            Source.ActorPublisher<string>(AllPersistenceIdsPublisher.Props(true, _writeJournalPluginId))
+            .MapMaterializedValue(_ => NotUsed.Instance)
+            .Named("AllPersistenceIds") as Source<string, NotUsed>;
+
+        /// <summary>
+        /// Same type of query as <see cref="PersistenceIds"/> but the stream
+        /// is completed immediately when it reaches the end of the "result set". Persistent
+        /// actors that are created after the query is completed are not included in the stream.
+        /// </summary>
+        public Source<string, NotUsed> CurrentPersistenceIds() =>
+            Source.ActorPublisher<string>(AllPersistenceIdsPublisher.Props(false, _writeJournalPluginId))
+            .MapMaterializedValue(_ => NotUsed.Instance)
+            .Named("CurrentPersistenceIds") as Source<string, NotUsed>;
+
+        /// <summary>
+        /// <see cref="EventsByPersistenceId"/> is used for retrieving events for a specific
+        /// <see cref="PersistentActor"/> identified by <see cref="Eventsourced.PersistenceId"/>.
+        /// <para>
+        /// You can retrieve a subset of all events by specifying <paramref name="fromSequenceNr"/> and <paramref name="toSequenceNr"/>
+        /// or use `0L` and <see cref="long.MaxValue"/> respectively to retrieve all events. Note that
+        /// the corresponding sequence number of each event is provided in the
+        /// <see cref="EventEnvelope"/>, which makes it possible to resume the
+        /// stream at a later point from a given sequence number.
+        /// </para>
+        /// The returned event stream is ordered by sequence number, i.e. the same order as the
+        /// <see cref="PersistentActor"/> persisted the events. The same prefix of stream elements (in same order)
+        ///  are returned for multiple executions of the query, except for when events have been deleted.
+        /// <para>
+        /// The stream is not completed when it reaches the end of the currently stored events,
+        /// but it continues to push new events when new events are persisted.
+        /// Corresponding query that is completed when it reaches the end of the currently
+        /// stored events is provided by <see cref="CurrentEventsByPersistenceId"/>.
+        /// </para>
+        /// The SQLite write journal is notifying the query side as soon as events are persisted, but for
+        /// efficiency reasons the query side retrieves the events in batches that sometimes can
+        /// be delayed up to the configured `refresh-interval`.
+        /// <para></para>
+        /// The stream is completed with failure if there is a failure in executing the query in the
+        /// backend journal.
+        /// </summary>
+        public Source<EventEnvelope, NotUsed> EventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) =>
+                Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+                    .MapMaterializedValue(_ => NotUsed.Instance)
+                    .Named("EventsByPersistenceId-" + persistenceId) as Source<EventEnvelope, NotUsed>;
+
+        /// <summary>
+        /// Same type of query as <see cref="EventsByPersistenceId"/> but the event stream
+        /// is completed immediately when it reaches the end of the "result set". Events that are
+        /// stored after the query is completed are not included in the event stream.
+        /// </summary>
+        public Source<EventEnvelope, NotUsed> CurrentEventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) =>
+                Source.ActorPublisher<EventEnvelope>(EventsByPersistenceIdPublisher.Props(persistenceId, fromSequenceNr, toSequenceNr, null, _maxBufferSize, _writeJournalPluginId))
+                    .MapMaterializedValue(_ => NotUsed.Instance)
+                    .Named("CurrentEventsByPersistenceId-" + persistenceId) as Source<EventEnvelope, NotUsed>;
+
+        /// <summary>
+        /// <see cref="EventsByTag"/> is used for retrieving events that were marked with
+        /// a given tag, e.g. all events of an Aggregate Root type.
+        /// <para></para>
+        /// To tag events you create an <see cref="IEventAdapter"/> that wraps the events
+        /// in a <see cref="Tagged"/> with the given `tags`.
+        /// <para></para>
+        /// You can use <see cref="NoOffset"/> to retrieve all events with a given tag or retrieve a subset of all
+        /// events by specifying a <see cref="Sequence"/>. The `offset` corresponds to an ordered sequence number for
+        /// the specific tag. Note that the corresponding offset of each event is provided in the
+        /// <see cref="EventEnvelope"/>, which makes it possible to resume the
+        /// stream at a later point from a given offset.
+        /// <para></para>
+        /// The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
+        /// in the returned stream.This means that you can use the offset that is returned in <see cref="EventEnvelope"/>
+        /// as the `offset` parameter in a subsequent query.
+        /// <para></para>
+        /// In addition to the <paramref name="offset"/> the <see cref="EventEnvelope"/> also provides `persistenceId` and `sequenceNr`
+        /// for each event. The `sequenceNr` is the sequence number for the persistent actor with the
+        /// `persistenceId` that persisted the event. The `persistenceId` + `sequenceNr` is an unique
+        /// identifier for the event.
+        /// <para></para>
+        /// The returned event stream is ordered by the offset (tag sequence number), which corresponds
+        /// to the same order as the write journal stored the events. The same stream elements (in same order)
+        /// are returned for multiple executions of the query. Deleted events are not deleted from the
+        /// tagged event stream.
+        /// <para></para>
+        /// The stream is not completed when it reaches the end of the currently stored events,
+        /// but it continues to push new events when new events are persisted.
+        /// Corresponding query that is completed when it reaches the end of the currently
+        /// stored events is provided by <see cref="CurrentEventsByTag"/>.
+        /// <para></para>
+        /// The SQL write journal is notifying the query side as soon as tagged events are persisted, but for
+        /// efficiency reasons the query side retrieves the events in batches that sometimes can
+        /// be delayed up to the configured `refresh-interval`.
+        /// <para></para>
+        /// The stream is completed with failure if there is a failure in executing the query in the
+        /// backend journal.
+        /// </summary>
+        public Source<EventEnvelope, NotUsed> EventsByTag(string tag, Offset offset = null)
+        {
+            offset = offset ?? new Sequence(0L);
+            switch (offset) {
+                case Sequence seq:
+                    return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, long.MaxValue, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+                        .MapMaterializedValue(_ => NotUsed.Instance)
+                        .Named($"EventsByTag-{tag}");
+                case NoOffset _:
+                    return EventsByTag(tag, new Sequence(0L));
+                default:
+                    throw new ArgumentException($"SqlReadJournal does not support {offset.GetType().Name} offsets");
+            }
+        }
+
+        /// <summary>
+        /// Same type of query as <see cref="EventsByTag"/> but the event stream
+        /// is completed immediately when it reaches the end of the "result set". Events that are
+        /// stored after the query is completed are not included in the event stream.
+        /// </summary>
+        public Source<EventEnvelope, NotUsed> CurrentEventsByTag(string tag, Offset offset = null)
+        {
+            offset = offset ?? new Sequence(0L);
+            switch (offset) {
+                case Sequence seq:
+                    return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, long.MaxValue, null, _maxBufferSize, _writeJournalPluginId))
+                        .MapMaterializedValue(_ => NotUsed.Instance)
+                        .Named($"CurrentEventsByTag-{tag}");
+                case NoOffset _:
+                    return CurrentEventsByTag(tag, new Sequence(0L));
+                default:
+                    throw new ArgumentException($"SqlReadJournal does not support {offset.GetType().Name} offsets");
+            }
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournalProvider.cs
+++ b/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournalProvider.cs
@@ -1,0 +1,32 @@
+﻿using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Query;
+
+namespace Akka.Persistence.MongoDb.Query
+{
+    public class MongoDbReadJournalProvider : IReadJournalProvider
+    {
+        private readonly ExtendedActorSystem _system;
+        private readonly Config _config;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="system">instance of actor system at which read journal should be started</param>
+        /// <param name="config"></param>
+        public MongoDbReadJournalProvider(ExtendedActorSystem system, Config config)
+        {
+            _system = system;
+            _config = config;
+        }
+
+        /// <summary>
+        /// Returns instance of EventStoreReadJournal
+        /// </summary>
+        /// <returns></returns>
+        public IReadJournal GetReadJournal()
+        {
+            return new MongoDbReadJournal(_system, _config);
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Query/SubscriptionDroppedException.cs
+++ b/src/Akka.Persistence.MongoDb/Query/SubscriptionDroppedException.cs
@@ -1,0 +1,23 @@
+﻿using Akka.Event;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akka.Persistence.MongoDb.Query
+{
+    public class SubscriptionDroppedException : Exception, IDeadLetterSuppression
+    {
+
+        public SubscriptionDroppedException() : this("Unknown error", null)
+        {
+
+        }
+
+        public SubscriptionDroppedException(string message, Exception inner) : base(message, inner)
+        {
+
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/SerializationResult.cs
+++ b/src/Akka.Persistence.MongoDb/SerializationResult.cs
@@ -1,0 +1,16 @@
+﻿using Akka.Serialization;
+
+namespace Akka.Persistence.MongoDb
+{
+    internal class SerializationResult
+    {
+        public SerializationResult(object payload, Serializer serializer)
+        {
+            Payload = payload;
+            Serializer = serializer;
+        }
+
+        public object Payload { get; }
+        public Serializer Serializer { get; }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Snapshot/SnapshotEntry.cs
+++ b/src/Akka.Persistence.MongoDb/Snapshot/SnapshotEntry.cs
@@ -28,5 +28,11 @@ namespace Akka.Persistence.MongoDb.Snapshot
 
         [BsonElement("Snapshot")]
         public object Snapshot { get; set; }
+
+        [BsonElement("Manifest")]
+        public string Manifest { get; set; }
+
+        [BsonElement("SerializerId")]
+        public int? SerializerId { get; set; }
     }
 }

--- a/src/Akka.Persistence.MongoDb/reference.conf
+++ b/src/Akka.Persistence.MongoDb/reference.conf
@@ -45,4 +45,26 @@
 			stored-as = object
 		}
 	}
+
+    query {
+        mongodb {
+            # Implementation class of the EventStore ReadJournalProvider
+            class = "Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb"
+
+            # Absolute path to the write journal plugin configuration entry that this 
+            # query journal will connect to. 
+            # If undefined (or "") it will connect to the default journal as specified by the
+            # akka.persistence.journal.plugin property.
+            write-plugin = ""
+
+            # The SQL write journal is notifying the query side as soon as things
+            # are persisted, but for efficiency reasons the query side retrieves the events 
+            # in batches that sometimes can be delayed up to the configured `refresh-interval`.
+            refresh-interval = 3s
+  
+            # How many events to fetch in one query (replay) and keep buffered until they
+            # are delivered downstreams.
+            max-buffer-size = 500
+        }
+    }
 }

--- a/src/Akka.Persistence.MongoDb/reference.conf
+++ b/src/Akka.Persistence.MongoDb/reference.conf
@@ -18,6 +18,9 @@
 
 			# metadata collection
 			metadata-collection = "Metadata"
+
+			# MongoDb type for payload field. Allowed: object, binary, default : object
+			stored-as = object
 		}
 	}
 
@@ -37,6 +40,9 @@
 
 			# MongoDb collection corresponding with persistent snapshot store
 			collection = "SnapshotStore"
+
+			# MongoDb type for payload field. Allowed: object, binary, default : object
+			stored-as = object
 		}
 	}
 }

--- a/src/common.props
+++ b/src/common.props
@@ -14,5 +14,6 @@
   <PropertyGroup>
     <XunitVersion>2.3.1</XunitVersion>
     <TestSdkVersion>15.3.0</TestSdkVersion>
+    <AkkaVersion>1.3.12</AkkaVersion>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <Copyright>Copyright © 2013-2018 Akka.NET Project</Copyright>
     <Authors>Akka.NET Contrib</Authors>
@@ -12,7 +12,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <XunitVersion>2.3.0</XunitVersion>
+    <XunitVersion>2.3.1</XunitVersion>
     <TestSdkVersion>15.3.0</TestSdkVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 1.3.12 April 05 2019 ####
Support for Akka.Persistence 1.3.12.
Added support for Akka.Persistence.Query.
Upgraded to MongoDb v2.7.0 driver (2.8.0 doesn't support .NET 4.5)
Added support for configurable, binary serialization via Akka.NET.